### PR TITLE
Check if user exists before attempting to access their properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+**1.5 (June 28, 2018)**
+
+* Improved support for Django 1.11, with initial support for 2.0
+
 **1.4 (June 8, 2017)**
 
 * New: localization for messages in admin. Russian locale available

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
-	DJANGO_SETTINGS_MODULE=locking.tests.settings django-admin.py collectstatic --link --noinput
-	DJANGO_SETTINGS_MODULE=locking.tests.settings django-admin.py test locking
+	DJANGO_SETTINGS_MODULE=tests.settings django-admin.py collectstatic --link --noinput
+	DJANGO_SETTINGS_MODULE=tests.settings django-admin.py test tests

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Prevents users from overwriting each others changes in Django.
 Django Admin Locking is tested in the following environments
 
 * Python (2.7, 3.4)
-* Django (1.8, 1.9, 1.10)
+* Django (1.8, 1.9, 1.10, 1.11)
 
 ## Installation
 

--- a/locking/models.py
+++ b/locking/models.py
@@ -80,9 +80,10 @@ class LockingManager(QueryMixin, models.Manager):
 
 class Lock(models.Model):
     id = models.CharField(max_length=15, primary_key=True)
-    locked_by = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'))
+    locked_by = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
+                                  on_delete=models.CASCADE)
     date_expires = models.DateTimeField()
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey('content_type', 'object_id')
 

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-admin-locking',
-    version='1.4',
+    version='1.5',
     url='https://github.com/joshmaker/django-admin-locking/',
-    download_url='https://github.com/joshmaker/django-admin-locking/tarball/v1.4',
+    download_url='https://github.com/joshmaker/django-admin-locking/tarball/v1.5',
     license='BSD',
     description='Prevents users from overwriting each others changes in Django.',
     author='Josh West',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -39,7 +39,7 @@ if GRAPPELLI_INSTALLED:
 
 MEDIA_URL = '/media/'   # Avoids https://code.djangoproject.com/ticket/21451
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -47,6 +47,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 ROOT_URLCONF = 'tests.urls'
 


### PR DESCRIPTION
There is a client-side 'undefined' error that arises because the locking javascript attempts to access (e.g.) the `username` of the user (..who may not exist). 